### PR TITLE
Item Upgrade compatibility

### DIFF
--- a/stratagems/spell/innate_triggers.tpa
+++ b/stratagems/spell/innate_triggers.tpa
@@ -194,4 +194,19 @@ END
      END
   END
 
+// this violates every ethos of David's being: straight tp2 code
+// I'm sure it will be rewritten to pass through 18 sfo functions across 6 different libraries
+// love ya David :)
+ACTION_IF (((MOD_IS_INSTALLED ~itemupgrade/itemupgrade.tp2~ ~0~) OR    // soa item upgrades, wes-style
+            (MOD_IS_INSTALLED ~itemupgrade/itemupgrade.tp2~ ~1~) OR    // tob item upgrades, wes-style
+            (MOD_IS_INSTALLED ~itemupgrade/itemupgrade.tp2~ ~10~) OR   // soa item upgrades, bg2-style
+            (MOD_IS_INSTALLED ~itemupgrade/itemupgrade.tp2~ ~11~)) AND // tob item upgrades, bg2-style
+            (FILE_EXISTS ~itemupgrade/bcs/scs_compat.baf~)) THEN BEGIN  // sanity check in case they downloaded an old IU 
 
+  ACTION_FOR_EACH area IN ar0334 ar4500 BEGIN
+    ACTION_IF FILE_EXISTS_IN_GAME ~%area%.are~ BEGIN
+      EXTEND_BOTTOM ~%area%.bcs~ ~itemupgrade/bcs/scs_compat.baf~ // adds an area var for crom and cespy to check in-game (crom has no script)
+    END
+  END
+
+END


### PR DESCRIPTION
SCS' component to make contingencies and sequencers innate abilities removes these spell scrolls since they're no longer needed. However, this leaves the Item Upgrade formula for the enhanced archmagi robes SOL as it uses these. SCS will now detect and add a small bit of scripting (provided by IU) so that Cespenar and Cromwell can adjust these formulae to require Globe of Invulnerability scrolls instead of Contingency.

Clearly, I've f'd up whitespace somewhere--the only new bit of code here is the last 15 lines or so. 