### PR TITLE
Fix cut&paste arcane instead of divine

### DIFF
--- a/stratagems/doc/readme-stratagems.html
+++ b/stratagems/doc/readme-stratagems.html
@@ -318,7 +318,7 @@ fully compatible with my Throne of Bhaal content-enhancement mod, Wheels of Prop
 <li>IWD restricts its Cause Wounds spells to evil casters (and its Cure Wounds spells to good casters), but the BG versions aren't so restricted. I remove the restrictions. (There is an ini option to override this; see <a href="#customisation"> here</a>.) In addition, BG Cause Wounds require a melee hit, whereas IWD Cause Wounds are just range=touch; I standardise to the IWD version.</li>
 <li>In IWD, summoning spells have green icons; in BG2, they have red icons. I recolor all BG2 summoning spells to green.</li>
 </ul>
-<p>A full list of arcane spells added, and documentation for each, can be found <a href="scs_iwd_desc_divine.html">here</a>.</p>
+<p>A full list of divine spells added, and documentation for each, can be found <a href="scs_iwd_desc_divine.html">here</a>.</p>
 <p>SCS's 'Smarter Priests' AI will detect and use the IWD spells if they are installed. In this case, some slightly more substantial tweaks will be made to the IWD spell system (see <a href="#iwd_tweaks_divine">here</a> for details).</p>
     </div>
   <div class="ribbon_rectangle_h3"><h3><a name="misctweaks" id="misctweaks"></a>Gameplay Tweaks</h3></div>


### PR DESCRIPTION
There's (I think) just a minor typo-kind error I stumbled upon while reading the doc.