### PR TITLE
Fixed incorrect price replacement, i.e. 20000 => 40.000 instead of 20000 => 40000

### DIFF
--- a/stratagems/gameplay/spellhold_cost.tpa
+++ b/stratagems/gameplay/spellhold_cost.tpa
@@ -16,9 +16,11 @@ BEGIN
     
     ACTION_FOR_EACH tlk_entry IN 6601 20944 20945 20970 20990 20991 21032 21512 21832 22046 34187 49061 49071 49839 49841 49844  BEGIN
           LAF substitute_tlk_entry INT_VAR tlk_entry 
-                                   STR_VAR arguments= ~               "20[, \.]?000" => "%asking_price_string%"
-                                                                      "15[, \.]?000" => "%actual_price_string%"
-                                                                      ~
+                                   STR_VAR arguments= ~               "20[, \.]000" => "%asking_price_string%"
+                                                                      "20000" => "%asking_price%"
+                                                                      "15[, \.]000" => "%actual_price_string%"
+                                                                      "15000" => "%actual_price%"
+                                                      ~
           END
     END
 


### PR DESCRIPTION
Fixed incorrect price replacement, i.e. `20000 => 40.000` instead of `20000 => 40000`

If an original string was without dots in the price, it should keep this formatting. 