### PR TITLE
Fixed incorrect identified/unidentified name for kobold's dagger.

### DIFF
--- a/stratagems/kobold/kobold.tpa
+++ b/stratagems/kobold/kobold.tpa
@@ -65,7 +65,7 @@ DEFINE_ACTION_FUNCTION kobold_core BEGIN
       // items
 
       // daggers
-      
+
       ACTION_IF enhanced_edition BEGIN
          OUTER_SET dagger_desc1=RESOLVE_STR_REF (@21316)
          OUTER_SET dagger_desc2=RESOLVE_STR_REF (@21317)
@@ -77,12 +77,13 @@ DEFINE_ACTION_FUNCTION kobold_core BEGIN
       END
 
       MAKE_PATCH
-         say_unidentified_name=>21305
-         say_name=>21304
+         say_unidentified_name=>21304
+         say_name=>21305
          description1_string=>~%dagger_desc1%~
          description2_string=>~%dagger_desc2%~
       END
-      LAF edit_item STR_VAR item=dw#kob01 edits=patch_data  END
+      LAF edit_item STR_VAR item=dw#kob01 edits=patch_data END
+      
       // arrows
       MAKE_PATCH
          say_unidentified_name=>21308


### PR DESCRIPTION
From kobold.tra:
(unidentified) `@21304 = ~Dagger~`
(identified) `@21305 = ~"Nome Stikka"~`