### PR TITLE
Removed unnecessary space in front of prepend.

### DIFF
--- a/stratagems/sfo/general/lib_text.tpa
+++ b/stratagems/sfo/general/lib_text.tpa
@@ -28,7 +28,7 @@ DEFINE_PATCH_FUNCTION prepend_string   // includes a space
                 arguments=""
         RET     output
 BEGIN
-   SPRINT ~output~ ~ %arguments% %input%~
+   SPRINT ~output~ ~%arguments% %input%~
 END
 
 DEFINE_PATCH_FUNCTION append_string_nospace


### PR DESCRIPTION
This function is used only to add "Prepare" word before spells like Sequencers or so. But as a result it generates string: " Prepare Sequencer" so in the UI buttons and dialog box it will have doubled space.