### PR TITLE
Fix reference to moved NPCs section in docs

### DIFF
--- a/stratagems/doc/readme-scs.html
+++ b/stratagems/doc/readme-scs.html
@@ -900,7 +900,7 @@ Minute Meteors, Contagion, Secret Word, Farsight, Wizard Eye
 <li>Tranzig: Glitterdust
 <li>Venkt: Spell Thrust
 </ul>
-<p><strong><a name="npc" id="npc"></a>Move NPCs to more convenient locations.</strong></p>
+<p><strong><a name="npcs" id="npc"></a>Move NPCs to more convenient locations.</strong></p>
 <p>
 The NPCs who are moved are:
 <ul>


### PR DESCRIPTION
Fix reference to moved NPCs section in docs.

In section `Non-Player Characters` there was a reference to "npcs" while the section was named "npc", then producing a broken link. Chosen to stick to the plural option.