### PR TITLE
Update French difficulty label

### DIFF
--- a/stratagems/lang/french/difficulty.tra
+++ b/stratagems/lang/french/difficulty.tra
@@ -1,275 +1,275 @@
 
 // general AI
 
-@101 = "Les ennemis ont une intelligence assez limitée et font preuve de peu de discrimination dans l'utilisation de leurs attaques et de leurs capacités. Les humanoïdes ennemis n'utilisent pas leurs capacités de classe et leurs objets magiques. Les groupes de créatures attaquent ensemble, mais n'appellent pas à l'aide d'autres groupes."
-@102 = "Les ennemis deviennent un peu plus intelligents, évitent les zones dangereuses et choisissent leurs cibles intelligemment. Ils n'utilisent toujours pas les objets et les capacités de classe. Les voleurs tenteront de se cacher s'ils sont hors du champ de vision du groupe."
-@103 = "Les ennemis utilisent des objets et des capacités de classe s'ils en ont ; en particulier, les voleurs utiliseront des potions d'invisibilité, s'ils en ont, pour se cacher en plein combat. Les ennemis choisissent souvent de commencer le combat à distance plutôt que de s'approcher de vous pour discuter. Les adversaires intelligents appellent parfois à l'aide les groupes voisins. Des voleurs et des guerriers de haut niveau sélectionnés utilisent des capacités de haut niveau."
-@104 = "Tous les guerriers et les voleurs éligibles utilisent des capacités de haut niveau."
+@101 = "Les ennemis ont une intelligence assez limitÃ©e et font preuve de peu de discrimination dans l'utilisation de leurs attaques et de leurs capacitÃ©s. Les humanoÃ¯des ennemis n'utilisent pas leurs capacitÃ©s de classe et leurs objets magiques. Les groupes de crÃ©atures attaquent ensemble, mais n'appellent pas Ã  l'aide d'autres groupes."
+@102 = "Les ennemis deviennent un peu plus intelligents, Ã©vitent les zones dangereuses et choisissent leurs cibles intelligemment. Ils n'utilisent toujours pas les objets et les capacitÃ©s de classe. Les voleurs tenteront de se cacher s'ils sont hors du champ de vision du groupe."
+@103 = "Les ennemis utilisent des objets et des capacitÃ©s de classe s'ils en ont ; en particulier, les voleurs utiliseront des potions d'invisibilitÃ©, s'ils en ont, pour se cacher en plein combat. Les ennemis choisissent souvent de commencer le combat Ã  distance plutÃ´t que de s'approcher de vous pour discuter. Les adversaires intelligents appellent parfois Ã  l'aide les groupes voisins. Des voleurs et des guerriers de haut niveau sÃ©lectionnÃ©s utilisent des capacitÃ©s de haut niveau."
+@104 = "Tous les guerriers et les voleurs Ã©ligibles utilisent des capacitÃ©s de haut niveau."
 
 // mage AI
 
-@111 = "Les mages ont une intelligence assez limitée. Ils renouvellent périodiquement leurs défenses et évitent dans une certaine mesure les utilisations imprudentes de leur magie, mais pas plus. Ils n'utilisent que des séquenceurs et des contingences défensives."
-@112 = "Les mages utilisent leurs sorts de manière intelligente, en choisissant les cibles les plus appropriées et en faisant attention à leurs propres défenses magiques. Ils s'abstiendront d'utiliser des séquenceurs et des contingences offensives."
-@113 = "Les mages utilisent des séquenceurs et des contingences offensives. Ils ont une chance de détecter la présence d'adversaires invisibles et d'utiliser la divination pour les révéler."
-@114 = "Les mages capables de le lancer utiliseront des Minuscules météores de Melf (et des sorts similaires) entre les sorts qu'ils lancent."
+@111 = "Les mages ont une intelligence assez limitÃ©e. Ils renouvellent pÃ©riodiquement leurs dÃ©fenses et Ã©vitent dans une certaine mesure les utilisations imprudentes de leur magie, mais pas plus. Ils n'utilisent que des sÃ©quenceurs et des contingences dÃ©fensives."
+@112 = "Les mages utilisent leurs sorts de maniÃ¨re intelligente, en choisissant les cibles les plus appropriÃ©es et en faisant attention Ã  leurs propres dÃ©fenses magiques. Ils s'abstiendront d'utiliser des sÃ©quenceurs et des contingences offensives."
+@113 = "Les mages utilisent des sÃ©quenceurs et des contingences offensives. Ils ont une chance de dÃ©tecter la prÃ©sence d'adversaires invisibles et d'utiliser la divination pour les rÃ©vÃ©ler."
+@114 = "Les mages capables de le lancer utiliseront des Minuscules mÃ©tÃ©ores de Melf (et des sorts similaires) entre les sorts qu'ils lancent."
 
 // mage buffing
 
-@121 = "Aucun mage ne lance de sorts avant le combat (bien qu'ils peuvent toujours utiliser les Séquenceurs et les Contingences pour ériger rapidement leurs défenses une fois le combat commencé)."
-@122 = "Les mages lancent à l'avance un petit nombre de sorts d'une durée d'au moins plusieurs heures (comme Peau de pierre)."
-@123 = "Les mages lancent à l'avance tous sorts défensifs d'une durée d'au moins un tour par niveau. S'ils sont dans le champ de vision du groupe, ils lancent également des sorts défensifs d'une durée d'au moins trois tours par niveau. S'ils sont hors du champ de vision du groupe, ils peuvent également lancer des sorts d'invocation de longue durée."
-@124 = "Les mages lancent à l'avance tous sorts défensifs d'une durée d'au moins trois tours par niveau. S'ils sont dans le champ de vision du groupe, ils lancent également des sorts défensifs d'une durée d'au moins un tour par niveau."
-@125 = "Les mages lancent à l'avance tous sorts défensifs d'une durée d'au moins un tour par niveau."
+@121 = "Aucun mage ne lance de sorts avant le combat (bien qu'ils peuvent toujours utiliser les SÃ©quenceurs et les Contingences pour Ã©riger rapidement leurs dÃ©fenses une fois le combat commencÃ©)."
+@122 = "Les mages lancent Ã  l'avance un petit nombre de sorts d'une durÃ©e d'au moins plusieurs heures (comme Peau de pierre)."
+@123 = "Les mages lancent Ã  l'avance tous sorts dÃ©fensifs d'une durÃ©e d'au moins un tour par niveau. S'ils sont dans le champ de vision du groupe, ils lancent Ã©galement des sorts dÃ©fensifs d'une durÃ©e d'au moins trois tours par niveau. S'ils sont hors du champ de vision du groupe, ils peuvent Ã©galement lancer des sorts d'invocation de longue durÃ©e."
+@124 = "Les mages lancent Ã  l'avance tous sorts dÃ©fensifs d'une durÃ©e d'au moins trois tours par niveau. S'ils sont dans le champ de vision du groupe, ils lancent Ã©galement des sorts dÃ©fensifs d'une durÃ©e d'au moins un tour par niveau."
+@125 = "Les mages lancent Ã  l'avance tous sorts dÃ©fensifs d'une durÃ©e d'au moins un tour par niveau."
 
 // mage HLAs
 
-@133 = "Aucun mage n'utilise de capacités de haut niveau."
-@134 = "Les mages particulièrement puissants utilisent des capacités de haut niveau, mais uniquement dans la section Throne of Bhaal du jeu."
-@135 = "Les mages particulièrement puissants utilisent des capacités de haut niveau, tout au long du jeu."
-@136 = "Tous les mages de la section Throne of Bhaal du jeu qui peuvent lancer des sorts de neuvième niveau utilisent des capacités de haut niveau. Dans le reste du jeu, seuls les mages particulièrement puissants les utilisent."
-@137 = "Tous les mages dans le jeu capables de lancer des sorts de neuvième niveau utilisent des capacités de haut niveau."
+@133 = "Aucun mage n'utilise de capacitÃ©s de haut niveau."
+@134 = "Les mages particuliÃ¨rement puissants utilisent des capacitÃ©s de haut niveau, mais uniquement dans la section Throne of Bhaal du jeu."
+@135 = "Les mages particuliÃ¨rement puissants utilisent des capacitÃ©s de haut niveau, tout au long du jeu."
+@136 = "Tous les mages de la section Throne of Bhaal du jeu qui peuvent lancer des sorts de neuviÃ¨me niveau utilisent des capacitÃ©s de haut niveau. Dans le reste du jeu, seuls les mages particuliÃ¨rement puissants les utilisent."
+@137 = "Tous les mages dans le jeu capables de lancer des sorts de neuviÃ¨me niveau utilisent des capacitÃ©s de haut niveau."
 
 // priest AI
 
-@141 = "Les clercs et les druides ont une intelligence assez limitée. Ils renouvelleront périodiquement leurs défenses et éviteront dans une certaine mesure les utilisations imprudentes de leur magie, mais pas plus."
-@142 = "Les clercs et les druides utilisent leurs sorts intelligemment, choisissant les cibles les plus appropriées, faisant attention à leurs propres défenses magiques, et soignant leurs alliés blessés ou handicapés. Les clercs repousseront ou contrôleront les morts-vivants hostiles, tandis que les druides utiliseront leurs capacités de changement de forme."
-@143 = "Les clercs et les druides ont une chance de sentir la présence d'adversaires invisibles et d'utiliser la divination pour les révéler."
+@141 = "Les clercs et les druides ont une intelligence assez limitÃ©e. Ils renouvelleront pÃ©riodiquement leurs dÃ©fenses et Ã©viteront dans une certaine mesure les utilisations imprudentes de leur magie, mais pas plus."
+@142 = "Les clercs et les druides utilisent leurs sorts intelligemment, choisissant les cibles les plus appropriÃ©es, faisant attention Ã  leurs propres dÃ©fenses magiques, et soignant leurs alliÃ©s blessÃ©s ou handicapÃ©s. Les clercs repousseront ou contrÃ´leront les morts-vivants hostiles, tandis que les druides utiliseront leurs capacitÃ©s de changement de forme."
+@143 = "Les clercs et les druides ont une chance de sentir la prÃ©sence d'adversaires invisibles et d'utiliser la divination pour les rÃ©vÃ©ler."
 
 
 // priest buffing
 
 @151 = "Aucun clerc ou druide ne lance de sorts avant le combat."
-@152 = "Les clercs et les druides lancent à l'avance un petit nombre de sorts d'une durée d'au moins plusieurs heures (comme Peaux de fer)."
-@153 = "Les clercs et les druides lancent à l'avance tous sorts défensifs d'une durée d'au moins un tour par niveau. S'ils sont dans le champ de vision du groupe, ils lancent également des sorts défensifs d'une durée d'au moins trois tours par niveau. S'ils sont hors du champ de vision du groupe, ils peuvent également lancer des sorts d'invocation de longue durée."
-@154 = "Les clercs et les druides lancent à l'avance tous sorts défensifs d'une durée d'au moins trois tours par niveau. S'ils sont dans le champ de vision du groupe, ils lancent également des sorts défensifs d'une durée d'au moins un tour par niveau."
-@155 = "Les clercs et les druides lancent à l'avance tous sorts défensifs d'une durée d'au moins un tour par niveau."
+@152 = "Les clercs et les druides lancent Ã  l'avance un petit nombre de sorts d'une durÃ©e d'au moins plusieurs heures (comme Peaux de fer)."
+@153 = "Les clercs et les druides lancent Ã  l'avance tous sorts dÃ©fensifs d'une durÃ©e d'au moins un tour par niveau. S'ils sont dans le champ de vision du groupe, ils lancent Ã©galement des sorts dÃ©fensifs d'une durÃ©e d'au moins trois tours par niveau. S'ils sont hors du champ de vision du groupe, ils peuvent Ã©galement lancer des sorts d'invocation de longue durÃ©e."
+@154 = "Les clercs et les druides lancent Ã  l'avance tous sorts dÃ©fensifs d'une durÃ©e d'au moins trois tours par niveau. S'ils sont dans le champ de vision du groupe, ils lancent Ã©galement des sorts dÃ©fensifs d'une durÃ©e d'au moins un tour par niveau."
+@155 = "Les clercs et les druides lancent Ã  l'avance tous sorts dÃ©fensifs d'une durÃ©e d'au moins un tour par niveau."
 
 // priest HLAs
 
-@163 = "Aucun clerc ou druide n'utilise de capacités de haut niveau."
-@164 = "Les clercs et les druides particulièrement puissants utilisent des capacités de haut niveau, mais seulement dans la section Throne of Bhaal du jeu."
-@165 = "Les clercs et les druides particulièrement puissants utilisent des capacités de haut niveau, tout au long du jeu."
-@166 = "Tous les clercs et druides de la section Throne of Bhaal du jeu qui peuvent lancer des sorts de septième niveau utilisent des capacités de haut niveau. Dans le reste du jeu, seuls les clercs et les druides particulièrement puissants les utilisent."
-@167 = "Tous les clercs et druides dans le jeu capables de lancer des sorts de septième niveau utilisent des capacités de haut niveau."
+@163 = "Aucun clerc ou druide n'utilise de capacitÃ©s de haut niveau."
+@164 = "Les clercs et les druides particuliÃ¨rement puissants utilisent des capacitÃ©s de haut niveau, mais seulement dans la section Throne of Bhaal du jeu."
+@165 = "Les clercs et les druides particuliÃ¨rement puissants utilisent des capacitÃ©s de haut niveau, tout au long du jeu."
+@166 = "Tous les clercs et druides de la section Throne of Bhaal du jeu qui peuvent lancer des sorts de septiÃ¨me niveau utilisent des capacitÃ©s de haut niveau. Dans le reste du jeu, seuls les clercs et les druides particuliÃ¨rement puissants les utilisent."
+@167 = "Tous les clercs et druides dans le jeu capables de lancer des sorts de septiÃ¨me niveau utilisent des capacitÃ©s de haut niveau."
 
 
 // spiders
 
-@171 = "Les araignées se comportent pratiquement comme elles le font dans le jeu non modifié."
-@172 = "Les araignées éclipsantes utilisent leur capacité de déplacement de manière raisonnablement intelligente pour cibler les adversaires, et l'utilisent parfois hors de l'écran."
-@173 = "Les araignées géantes acquièrent la capacité de cracher des toiles."
-@174 = "Les araignées géantes ont une attaque de morsure modifiée qui fait moins de dégâts de poison, mais qui piège la cible dans une toile."
+@171 = "Les araignÃ©es se comportent pratiquement comme elles le font dans le jeu non modifiÃ©."
+@172 = "Les araignÃ©es Ã©clipsantes utilisent leur capacitÃ© de dÃ©placement de maniÃ¨re raisonnablement intelligente pour cibler les adversaires, et l'utilisent parfois hors de l'Ã©cran."
+@173 = "Les araignÃ©es gÃ©antes acquiÃ¨rent la capacitÃ© de cracher des toiles."
+@174 = "Les araignÃ©es gÃ©antes ont une attaque de morsure modifiÃ©e qui fait moins de dÃ©gÃ¢ts de poison, mais qui piÃ¨ge la cible dans une toile."
 
 // vampires
 
-@181 = "Les vampires se battent de manière peu intelligente et n'utilisent pas leurs capacités surnaturelles, si ce n'est pour changer de forme occasionnellement."
-@182 = "Les vampires font preuve de plus de soin dans le choix de leurs cibles, recherchant activement des cibles vulnérables. Ils utilisent leur regard de domination sur leurs adversaires."
-@183 = "Certains vampires invoquent des rats, des chauves-souris ou des loups pour les aider. Tous les vampires acquièrent la capacité de boire du sang (drainant la constitution) ainsi que d'attaquer avec un drain d'énergie. Certains vampires puissants acquièrent d'autres pouvoirs surnaturels."
-@184 = "Certains vampires plus puissants acquièrent d'autres pouvoirs surnaturels, hypnotisant leurs adversaires ou prenant une forme de brume pour les surprendre."
+@181 = "Les vampires se battent de maniÃ¨re peu intelligente et n'utilisent pas leurs capacitÃ©s surnaturelles, si ce n'est pour changer de forme occasionnellement."
+@182 = "Les vampires font preuve de plus de soin dans le choix de leurs cibles, recherchant activement des cibles vulnÃ©rables. Ils utilisent leur regard de domination sur leurs adversaires."
+@183 = "Certains vampires invoquent des rats, des chauves-souris ou des loups pour les aider. Tous les vampires acquiÃ¨rent la capacitÃ© de boire du sang (drainant la constitution) ainsi que d'attaquer avec un drain d'Ã©nergie. Certains vampires puissants acquiÃ¨rent d'autres pouvoirs surnaturels."
+@184 = "Certains vampires plus puissants acquiÃ¨rent d'autres pouvoirs surnaturels, hypnotisant leurs adversaires ou prenant une forme de brume pour les surprendre."
 
 // Bodhi
 
-@191 = "Bodhi n'est protégée que par des vampires novices et par quelques autres morts-vivants, et utilise peu de capacités surnaturelles."
-@192 = "Bodhi utilise ses pouvoirs surnaturels Enterré vivant (ralentissement et affaiblissement), Toucher de la mort (Toucher vampirique) et Appel de la maîtresse (Contrôle des morts-vivants). Ses alliés incluent également deux vampires."
-@193 = "Bodhi utilise également son Nuage de chauves-souris (semblable à Fléau d'insectes), Ténèbres abyssales (Cécité) et Sommeil sépulcral (inconscience). Ses alliés comprennent également quatre vampires adultes."
-@194 = "Bodhi utilise également son pouvoir surnaturel Froid de la tombe (dégât de froid). Elle est aidée par deux mages vampires."
-@195 = "Les capacités physiques et les résistances de Bodhi sont considérablement améliorées. Elle gagne un Linceul mortel permanent (Bouclier de feu (bleu)) et est immunisée contre les sorts de premier et de second niveau. Deux anciens vampires se joignent à ses protecteurs."
+@191 = "Bodhi n'est protÃ©gÃ©e que par des vampires novices et par quelques autres morts-vivants, et utilise peu de capacitÃ©s surnaturelles."
+@192 = "Bodhi utilise ses pouvoirs surnaturels EnterrÃ© vivant (ralentissement et affaiblissement), Toucher de la mort (Toucher vampirique) et Appel de la maÃ®tresse (ContrÃ´le des morts-vivants). Ses alliÃ©s incluent Ã©galement deux vampires."
+@193 = "Bodhi utilise Ã©galement son Nuage de chauves-souris (semblable Ã  FlÃ©au d'insectes), TÃ©nÃ¨bres abyssales (CÃ©citÃ©) et Sommeil sÃ©pulcral (inconscience). Ses alliÃ©s comprennent Ã©galement quatre vampires adultes."
+@194 = "Bodhi utilise Ã©galement son pouvoir surnaturel Froid de la tombe (dÃ©gÃ¢t de froid). Elle est aidÃ©e par deux mages vampires."
+@195 = "Les capacitÃ©s physiques et les rÃ©sistances de Bodhi sont considÃ©rablement amÃ©liorÃ©es. Elle gagne un Linceul mortel permanent (Bouclier de feu (bleu)) et est immunisÃ©e contre les sorts de premier et de second niveau. Deux anciens vampires se joignent Ã  ses protecteurs."
 
 // Dragons
 
-@201 = "Les dragons se comportent pratiquement comme dans le jeu non modifié, bien qu'ils n'utilisent pas de séquenceurs de sorts ni de déclencheurs de sorts."
-@202 = "Les dragons utilisent des séquenceurs de sorts et des déclencheurs de sorts, et sont assez intelligents pour attaquer de manière préventive si le groupe se prépare clairement à les attaquer."
-@203 = "Les dragons acquièrent le pouvoir de lancer leurs sorts instantanément et sans risque d'interruption."
-@204 = "Les dragons bénéficient d'une augmentation significative (+ 200 %) de leurs points de vie."
-@205 = "Les dragons ont 50 % de chances à chaque tour de retrouver l'usage de leur souffle."
+@201 = "Les dragons se comportent pratiquement comme dans le jeu non modifiÃ©, bien qu'ils n'utilisent pas de sÃ©quenceurs de sorts ni de dÃ©clencheurs de sorts."
+@202 = "Les dragons utilisent des sÃ©quenceurs de sorts et des dÃ©clencheurs de sorts, et sont assez intelligents pour attaquer de maniÃ¨re prÃ©ventive si le groupe se prÃ©pare clairement Ã  les attaquer."
+@203 = "Les dragons acquiÃ¨rent le pouvoir de lancer leurs sorts instantanÃ©ment et sans risque d'interruption."
+@204 = "Les dragons bÃ©nÃ©ficient d'une augmentation significative (+ 200 %) de leurs points de vie."
+@205 = "Les dragons ont 50 % de chances Ã  chaque tour de retrouver l'usage de leur souffle."
 
 // Drow
 
-@211 = "Ust Natha est défendue par deux groupes désorganisés de drows et une force d'élite de mages et de clercs."
-@212 = "Ust Natha est défendue par quatre groupes désorganisés de drows et une force d'élite de mages et de clercs."
-@213 = "Ust Natha est défendue par quatre groupes désorganisés, une troupe de guerre organisée et trois groupes d'élite."
-@214 = "Ust Natha est défendue par quatre groupes désorganisés, trois troupes de guerre organisées, un groupe d'élite de mages et une mère matrone avec ses alliés démoniaques."
-@215 = "Ust Natha est défendue par quatre groupes désorganisés, sept troupes de guerre organisées, deux groupes d'élite de mages et de clercs, un groupe d'élite de mages, et une mère matrone avec ses alliés démoniaques."
+@211 = "Ust Natha est dÃ©fendue par deux groupes dÃ©sorganisÃ©s de drows et une force d'Ã©lite de mages et de clercs."
+@212 = "Ust Natha est dÃ©fendue par quatre groupes dÃ©sorganisÃ©s de drows et une force d'Ã©lite de mages et de clercs."
+@213 = "Ust Natha est dÃ©fendue par quatre groupes dÃ©sorganisÃ©s, une troupe de guerre organisÃ©e et trois groupes d'Ã©lite."
+@214 = "Ust Natha est dÃ©fendue par quatre groupes dÃ©sorganisÃ©s, trois troupes de guerre organisÃ©es, un groupe d'Ã©lite de mages et une mÃ¨re matrone avec ses alliÃ©s dÃ©moniaques."
+@215 = "Ust Natha est dÃ©fendue par quatre groupes dÃ©sorganisÃ©s, sept troupes de guerre organisÃ©es, deux groupes d'Ã©lite de mages et de clercs, un groupe d'Ã©lite de mages, et une mÃ¨re matrone avec ses alliÃ©s dÃ©moniaques."
 
 // Durlag's Tower
 
-@221 = "Les gardiens du premier niveau (Amour, Fierté, etc...) n'utilisent pas de capacités surnaturelles."
+@221 = "Les gardiens du premier niveau (Amour, FiertÃ©, etc...) n'utilisent pas de capacitÃ©s surnaturelles."
 @222 = "Les gardiens utilisent leurs pouvoirs surnaturels, mais assez rarement."
-@223 = "Les gardiens utilisent plus fréquemment leurs pouvoirs surnaturels."
-@224 = "Les gardiens utilisent leurs pouvoirs presque constamment. Le miroir du chevalier-démon génère des copies du groupe, et non des copies génériques de démons, et le chevalier-démon lui-même est considérablement amélioré."
+@223 = "Les gardiens utilisent plus frÃ©quemment leurs pouvoirs surnaturels."
+@224 = "Les gardiens utilisent leurs pouvoirs presque constamment. Le miroir du chevalier-dÃ©mon gÃ©nÃ¨re des copies du groupe, et non des copies gÃ©nÃ©riques de dÃ©mons, et le chevalier-dÃ©mon lui-mÃªme est considÃ©rablement amÃ©liorÃ©."
 
 // Beholders
 
-@231 = "Les spectateurs utilisent surtout leurs pédoncules les moins mortels (charme, peur, domination, paralysie, blessures, lenteur) et n'utilisent pas leur œil central qui supprime la magie. Les Reines-mères n'utilisent que leur magie la plus faible."
-@232 = "Les spectateurs utilisent également leur œil central contre les mages et les défenses du groupe. Les Reines-mères utilisent toute leur gamme de sorts."
-@233 = "Les spectateurs utilisent leurs pédoncules de mort, de pétrification et de télékinésie."
-@234 = "Les spectateurs utilisent leurs pédoncules de télékinésie pour voler certains objets du groupe (notamment le Bouclier de Baldurien, si vous l'avez)."
-@235 = "Les spectateurs utilisent leurs pédoncules de désintégration."
+@231 = "Les spectateurs utilisent surtout leurs pÃ©doncules les moins mortels (charme, peur, domination, paralysie, blessures, lenteur) et n'utilisent pas leur Å“il central qui supprime la magie. Les Reines-mÃ¨res n'utilisent que leur magie la plus faible."
+@232 = "Les spectateurs utilisent Ã©galement leur Å“il central contre les mages et les dÃ©fenses du groupe. Les Reines-mÃ¨res utilisent toute leur gamme de sorts."
+@233 = "Les spectateurs utilisent leurs pÃ©doncules de mort, de pÃ©trification et de tÃ©lÃ©kinÃ©sie."
+@234 = "Les spectateurs utilisent leurs pÃ©doncules de tÃ©lÃ©kinÃ©sie pour voler certains objets du groupe (notamment le Bouclier de Baldurien, si vous l'avez)."
+@235 = "Les spectateurs utilisent leurs pÃ©doncules de dÃ©sintÃ©gration."
 
 // Illithids
 
-@241 = "Les flagelleurs mentaux utilisent peu de pouvoirs, et les utilisent de manière peu intelligente."
-@242 = "Les flagelleurs mentaux utilisent Labyrinthe et des Souffles psioniques. Leur intelligence générale pour choisir leurs cibles s'améliore."
-@243 = "L'intelligence surhumaine des flagelleurs mentaux leur permet d'ignorer les sorts d'Invisibilité. Ils utilisent le Voyage planaire pour se déplacer rapidement sur le champ de bataille, se cachent avec leur invisibilité psionique, et sont trop alertes pour que le groupe puisse se reposer dans leur cité."
-@244 = "L'étrange physiologie des flagelleurs mentaux et leurs protections psioniques leur confèrent une résistance de 50 % aux dégâts physiques. Les flagelleurs mentaux utilisent leurs pouvoirs psioniques pour détruire rapidement des adversaires non-vivants tels que les squelettes."
+@241 = "Les flagelleurs mentaux utilisent peu de pouvoirs, et les utilisent de maniÃ¨re peu intelligente."
+@242 = "Les flagelleurs mentaux utilisent Labyrinthe et des Souffles psioniques. Leur intelligence gÃ©nÃ©rale pour choisir leurs cibles s'amÃ©liore."
+@243 = "L'intelligence surhumaine des flagelleurs mentaux leur permet d'ignorer les sorts d'InvisibilitÃ©. Ils utilisent le Voyage planaire pour se dÃ©placer rapidement sur le champ de bataille, se cachent avec leur invisibilitÃ© psionique, et sont trop alertes pour que le groupe puisse se reposer dans leur citÃ©."
+@244 = "L'Ã©trange physiologie des flagelleurs mentaux et leurs protections psioniques leur confÃ¨rent une rÃ©sistance de 50 % aux dÃ©gÃ¢ts physiques. Les flagelleurs mentaux utilisent leurs pouvoirs psioniques pour dÃ©truire rapidement des adversaires non-vivants tels que les squelettes."
 
 // Spawns
 
-@252 = "L'apparition aléatoire des monstres est comme dans le jeu non modifié (donc, liée au niveau et à la progression dans le jeu)."
-@253 = "L'apparition aléatoire des monstres est légèrement améliorée par rapport au jeu non modifié."
-@254 = "L'apparition aléatoire des monstres est significativement améliorée par rapport au jeu non modifié."
-@255 = "L'apparition aléatoire des monstres est considérablement améliorée par rapport au jeu non modifié, et certaines apparitions exceptionnellement dangereuses peuvent se produire tardivement dans le jeu."
-@256 = "L'apparition aléatoire des monstres est très considérablement améliorée tout au long du jeu, et les apparitions exceptionnellement dangereuses se produisent maintenant plus tôt dans le jeu."
-@257 = "Les monstres les plus dangereux apparaîtront constamment, quel que soit le stade du jeu où vous vous trouvez."
+@252 = "L'apparition alÃ©atoire des monstres est comme dans le jeu non modifiÃ© (donc, liÃ©e au niveau et Ã  la progression dans le jeu)."
+@253 = "L'apparition alÃ©atoire des monstres est lÃ©gÃ¨rement amÃ©liorÃ©e par rapport au jeu non modifiÃ©."
+@254 = "L'apparition alÃ©atoire des monstres est significativement amÃ©liorÃ©e par rapport au jeu non modifiÃ©."
+@255 = "L'apparition alÃ©atoire des monstres est considÃ©rablement amÃ©liorÃ©e par rapport au jeu non modifiÃ©, et certaines apparitions exceptionnellement dangereuses peuvent se produire tardivement dans le jeu."
+@256 = "L'apparition alÃ©atoire des monstres est trÃ¨s considÃ©rablement amÃ©liorÃ©e tout au long du jeu, et les apparitions exceptionnellement dangereuses se produisent maintenant plus tÃ´t dans le jeu."
+@257 = "Les monstres les plus dangereux apparaÃ®tront constamment, quel que soit le stade du jeu oÃ¹ vous vous trouvez."
 
 // Fiends
 
-@261 = "Les démons se battent de manière peu intelligente. Ils utiliseront certains de leurs pouvoirs magiques offensifs, mais pas les plus meurtriers, ne se téléporteront pas, n'attaqueront pas vos défenses magiques et ne renouvelleront pas les leurs."
-@262 = "Les démons choisiront leurs cibles intelligemment, attaqueront vos défenses magiques et utiliseront la plupart de leurs pouvoirs magiques offensifs."
-@263 = "Les démons peuvent utiliser leurs pouvoirs magiques instantanément et sans risque d'interruption. Ils se téléporteront sur le champ de bataille pour obtenir un avantage tactique, tenteront de renouveler leurs propres défenses et utiliseront tous leurs pouvoirs magiques. Les princes démons invoqueront des démons une fois tous les trois tours."
-@264 = "Les démons reçoivent une augmentation (+50 %) de leurs points de vie. Les balors utiliseront leur pouvoir d'Implosion, mais uniquement dans Throne of Bhaal. Les princes démons invoqueront des démons une fois tous les deux tours."
-@265 = "Les balors utiliseront leur pouvoir d'Implosion tout au long du jeu. Les princes démons invoqueront des démons une fois par tour."
+@261 = "Les dÃ©mons se battent de maniÃ¨re peu intelligente. Ils utiliseront certains de leurs pouvoirs magiques offensifs, mais pas les plus meurtriers, ne se tÃ©lÃ©porteront pas, n'attaqueront pas vos dÃ©fenses magiques et ne renouvelleront pas les leurs."
+@262 = "Les dÃ©mons choisiront leurs cibles intelligemment, attaqueront vos dÃ©fenses magiques et utiliseront la plupart de leurs pouvoirs magiques offensifs."
+@263 = "Les dÃ©mons peuvent utiliser leurs pouvoirs magiques instantanÃ©ment et sans risque d'interruption. Ils se tÃ©lÃ©porteront sur le champ de bataille pour obtenir un avantage tactique, tenteront de renouveler leurs propres dÃ©fenses et utiliseront tous leurs pouvoirs magiques. Les princes dÃ©mons invoqueront des dÃ©mons une fois tous les trois tours."
+@264 = "Les dÃ©mons reÃ§oivent une augmentation (+50 %) de leurs points de vie. Les balors utiliseront leur pouvoir d'Implosion, mais uniquement dans Throne of Bhaal. Les princes dÃ©mons invoqueront des dÃ©mons une fois tous les deux tours."
+@265 = "Les balors utiliseront leur pouvoir d'Implosion tout au long du jeu. Les princes dÃ©mons invoqueront des dÃ©mons une fois par tour."
 
 // Genies
 
-@271 = "Les génies attaquent de manière peu intelligente, et n'utilisent pas leurs Invisibilité ou leurs pouvoirs de protection."
-@272 = "Les génies attaquent intelligemment et utilisent tous leurs pouvoirs magiques."
-@273 = "Les génies peuvent utiliser leurs pouvoirs magiques instantanément et sans risque d'interruption."
-@274 = "Les génies reçoivent une augmentation (+50 %) de leurs points de vie."
+@271 = "Les gÃ©nies attaquent de maniÃ¨re peu intelligente, et n'utilisent pas leurs InvisibilitÃ© ou leurs pouvoirs de protection."
+@272 = "Les gÃ©nies attaquent intelligemment et utilisent tous leurs pouvoirs magiques."
+@273 = "Les gÃ©nies peuvent utiliser leurs pouvoirs magiques instantanÃ©ment et sans risque d'interruption."
+@274 = "Les gÃ©nies reÃ§oivent une augmentation (+50 %) de leurs points de vie."
 
 // Beholder hive
 
-@281 = "L'orbe ancien est déplacé vers un endroit plus sensible dans la ruche, mais il n'y a pas d'autres changements."
-@282 = "Un spectateur est ajouté à la ruche."
-@283 = "Une Reine-mère et un spectateur sont ajoutés à la ruche."
-@284 = "Une Reine-mère, un spectateur et deux tyramorts sont ajoutés à la ruche."
-@285 = "Une Reine-mère, trois spectateurs, deux tyramorts et deux gauths sont ajoutés à la ruche."
+@281 = "L'orbe ancien est dÃ©placÃ© vers un endroit plus sensible dans la ruche, mais il n'y a pas d'autres changements."
+@282 = "Un spectateur est ajoutÃ© Ã  la ruche."
+@283 = "Une Reine-mÃ¨re et un spectateur sont ajoutÃ©s Ã  la ruche."
+@284 = "Une Reine-mÃ¨re, un spectateur et deux tyramorts sont ajoutÃ©s Ã  la ruche."
+@285 = "Une Reine-mÃ¨re, trois spectateurs, deux tyramorts et deux gauths sont ajoutÃ©s Ã  la ruche."
 
 // Spellholditems
 
-@293 = "Un golem d'argile (difficile à blesser, et qui inflige des blessures maudites dans SCS) est retiré de l'asile."
-@294 = "Le golem d'argile est laissé en place."
+@293 = "Un golem d'argile (difficile Ã  blesser, et qui inflige des blessures maudites dans SCS) est retirÃ© de l'asile."
+@294 = "Le golem d'argile est laissÃ© en place."
 
 
 // d'Arnise trolls
 
-@301 = "Des trolls supplémentaires peuvent être trouvés dans tout le donjon. Les trolls fantômes ont une résistance accrue aux dommages."
-@302 = "Torgal est soutenu par une ombre des roches alliée."
-@303 = "Torgal est également soutenu par un mage yuan-ti, et peut invoquer un Manteau de terreur. Les trolls fantômes ont des pouvoirs de clercs offensifs, utilisables une fois tous les 10 tours."
-@304 = "Torgal a maintenant deux mages yuan-ti alliés. Les trolls fantômes peuvent utiliser leurs pouvoirs tous les 3-4 tours."
-@305 = "Les mages de Torgal et l'ombre des roches gagnent en puissance. Les trolls fantômes peuvent utiliser leurs pouvoirs tous les 2-3 tours."
+@301 = "Des trolls supplÃ©mentaires peuvent Ãªtre trouvÃ©s dans tout le donjon. Les trolls fantÃ´mes ont une rÃ©sistance accrue aux dommages."
+@302 = "Torgal est soutenu par une ombre des roches alliÃ©e."
+@303 = "Torgal est Ã©galement soutenu par un mage yuan-ti, et peut invoquer un Manteau de terreur. Les trolls fantÃ´mes ont des pouvoirs de clercs offensifs, utilisables une fois tous les 10 tours."
+@304 = "Torgal a maintenant deux mages yuan-ti alliÃ©s. Les trolls fantÃ´mes peuvent utiliser leurs pouvoirs tous les 3-4 tours."
+@305 = "Les mages de Torgal et l'ombre des roches gagnent en puissance. Les trolls fantÃ´mes peuvent utiliser leurs pouvoirs tous les 2-3 tours."
 
 // doppelgangers
 
-@313 = "Les doppelgängers sont à leur niveau de base."
-@314 = "Certains doppelgängers obtiennent une augmentation de leur score de capacité."
+@313 = "Les doppelgÃ¤ngers sont Ã  leur niveau de base."
+@314 = "Certains doppelgÃ¤ngers obtiennent une augmentation de leur score de capacitÃ©."
 
 // Ascension
 
-@321 = "Les capacités de Mélissanne sont fortement limitées, et elle n'apparaît que tard dans la bataille finale. Vous récupérez des sorts et des capacités trois fois avant la bataille finale. Les cinq évitent d'utiliser leurs capacités les plus puissantes."
-@322 = "Mélissanne et les cinq ont légèrement moins de restrictions de leurs capacités."
-@323 = "Mélissanne et les cinq reçoivent la plupart de leurs capacités, et Mélissanne peut invoquer des démons. Mélissanne apparaît à mi-chemin de la bataille avec les cinq. Vous récupérez deux fois des sorts et des capacités avant la bataille finale."
-@324 = "Mélissanne et les cinq utilisent toutes leurs capacités. Yaga-Shura commence avec une résistance de 100 % à la plupart des formes de dégâts (qui diminuera au fil du temps). Mélissanne apparaît tôt dans la bataille avec les cinq, et invoque des démons plus rapidement. Sarevok envisagera de vous trahir s'il est un membre de votre groupe. Vous ne récupérez les sorts et les capacités qu'une seule fois avant la bataille finale."
-@325 = "Mélissanne apparaît dès qu'un des cinq est tué, convoque des démons encore plus rapidement et peut également invoquer des solaires déchus. Le chapitre 10 tout entier ne vous permet pas de vous reposer."
+@321 = "Les capacitÃ©s de MÃ©lissanne sont fortement limitÃ©es, et elle n'apparaÃ®t que tard dans la bataille finale. Vous rÃ©cupÃ©rez des sorts et des capacitÃ©s trois fois avant la bataille finale. Les cinq Ã©vitent d'utiliser leurs capacitÃ©s les plus puissantes."
+@322 = "MÃ©lissanne et les cinq ont lÃ©gÃ¨rement moins de restrictions de leurs capacitÃ©s."
+@323 = "MÃ©lissanne et les cinq reÃ§oivent la plupart de leurs capacitÃ©s, et MÃ©lissanne peut invoquer des dÃ©mons. MÃ©lissanne apparaÃ®t Ã  mi-chemin de la bataille avec les cinq. Vous rÃ©cupÃ©rez deux fois des sorts et des capacitÃ©s avant la bataille finale."
+@324 = "MÃ©lissanne et les cinq utilisent toutes leurs capacitÃ©s. Yaga-Shura commence avec une rÃ©sistance de 100 % Ã  la plupart des formes de dÃ©gÃ¢ts (qui diminuera au fil du temps). MÃ©lissanne apparaÃ®t tÃ´t dans la bataille avec les cinq, et invoque des dÃ©mons plus rapidement. Sarevok envisagera de vous trahir s'il est un membre de votre groupe. Vous ne rÃ©cupÃ©rez les sorts et les capacitÃ©s qu'une seule fois avant la bataille finale."
+@325 = "MÃ©lissanne apparaÃ®t dÃ¨s qu'un des cinq est tuÃ©, convoque des dÃ©mons encore plus rapidement et peut Ã©galement invoquer des solaires dÃ©chus. Le chapitre 10 tout entier ne vous permet pas de vous reposer."
 
 // dragons (IWD)
 
-@401 = "Les dragons se comportent pratiquement comme dans le jeu non modifié, en évitant toute utilisation de capacités magiques."
+@401 = "Les dragons se comportent pratiquement comme dans le jeu non modifiÃ©, en Ã©vitant toute utilisation de capacitÃ©s magiques."
 @402 = "Les dragons peuvent utiliser un petit nombre de sorts et de pouvoirs magiques."
-@403 = "Les dragons acquièrent le pouvoir de lancer leurs sorts instantanément et sans risque d'interruption. Le nombre et la puissance de ses sorts augmentent."
-@404 = "Les dragons utilisent des séquenceurs de sorts."
-@405 = "Les dragons ont 50 % de chances à chaque tour de retrouver l'usage de leur souffle."
+@403 = "Les dragons acquiÃ¨rent le pouvoir de lancer leurs sorts instantanÃ©ment et sans risque d'interruption. Le nombre et la puissance de ses sorts augmentent."
+@404 = "Les dragons utilisent des sÃ©quenceurs de sorts."
+@405 = "Les dragons ont 50 % de chances Ã  chaque tour de retrouver l'usage de leur souffle."
 
 
-@1010 = ~Cette difficulté est actuellement fixée à DÉFAUT (difficulté déterminée par le curseur de difficulté générale).~
-@1011 = ~La difficulté de cette partie du jeu est actuellement fixée à MODE HISTOIRE.~
-@1012 = ~La difficulté de cette partie du jeu est actuellement fixée à FACILE.~
-@1013 = ~La difficulté de cette partie du jeu est actuellement fixée à NORMAL.~
-@1014 = ~La difficulté de cette partie du jeu est actuellement fixée à RÈGLE DE BASE.~
-@1015 = ~La difficulté de cette partie du jeu est actuellement fixée à DIFFICILE.~
-@1016 = ~La difficulté de cette partie du jeu est actuellement fixée à TRÈS DIFFICILE.~
-@1017 = ~La difficulté de cette partie du jeu est actuellement fixée à SUCCESSION DE BHAAL.~
-@1018 = ~Réglage des paramètres de difficulté~
-@1019 = ~Laissez la difficulté de cette partie du jeu inchangée.~
-@1020 = ~Changer la difficulté à DÉFAUT (difficulté déterminée par le curseur de difficulté générale).~
-@1021 = ~Changer la difficulté à MODE HISTOIRE : ~
-@1022 = ~Changer la difficulté à FACILE : ~
-@1023 = ~Changer la difficulté à NORMAL : ~
-@1024 = ~Changer la difficulté à RÈGLE DE BASE : ~
-@1025 = ~Changer la difficulté à DIFFICILE : ~
-@1026 = ~Changer la difficulté à TRÈS DIFFICILE : ~
-@1027 = ~Changer la difficulté à SUCCESSION DE BHAAL : ~
-@1028 = ~La difficulté de cette partie du jeu est actuellement fixée à CŒUR DE FURIE.~
-@1029 = ~Changer la difficulté à CŒUR DE FURIE : ~
-@1030 = ~Quel paramètre de difficulté voulez-vous changer ?~
+@1010 = ~Cette difficultÃ© est actuellement fixÃ©e Ã  DÃ‰FAUT (difficultÃ© dÃ©terminÃ©e par le curseur de difficultÃ© gÃ©nÃ©rale).~
+@1011 = ~La difficultÃ© de cette partie du jeu est actuellement fixÃ©e Ã  BASIQUE.~
+@1012 = ~La difficultÃ© de cette partie du jeu est actuellement fixÃ©e Ã  AMÃ‰LIORÃ‰E.~
+@1013 = ~La difficultÃ© de cette partie du jeu est actuellement fixÃ©e Ã  TACTIQUE.~
+@1014 = ~La difficultÃ© de cette partie du jeu est actuellement fixÃ©e Ã  DIFFICILE.~
+@1015 = ~La difficultÃ© de cette partie du jeu est actuellement fixÃ©e Ã  TRÃˆS DIFFICILE.~
+@1016 = ~La difficultÃ© de cette partie du jeu est actuellement fixÃ©e Ã  DÃ‰MENTIELLE.~
+@1017 = ~La difficultÃ© de cette partie du jeu est actuellement fixÃ©e Ã  SUCCESSION DE BHAAL.~
+@1018 = ~RÃ©glage des paramÃ¨tres de difficultÃ©~
+@1019 = ~Laissez la difficultÃ© de cette partie du jeu inchangÃ©e.~
+@1020 = ~Changer la difficultÃ© Ã  DÃ‰FAUT (difficultÃ© dÃ©terminÃ©e par le curseur de difficultÃ© gÃ©nÃ©rale).~
+@1021 = ~Changer la difficultÃ© Ã  BASIQUE : ~
+@1022 = ~Changer la difficultÃ© Ã  AMÃ‰LIORÃ‰E : ~
+@1023 = ~Changer la difficultÃ© Ã  TACTIQUE : ~
+@1024 = ~Changer la difficultÃ© Ã  DIFFICILE : ~
+@1025 = ~Changer la difficultÃ© Ã  TRÃˆS DIFFICILE : ~
+@1026 = ~Changer la difficultÃ© Ã  DÃ‰MENTIELLE : ~
+@1027 = ~Changer la difficultÃ© Ã  SUCCESSION DE BHAAL : ~
+@1028 = ~La difficultÃ© de cette partie du jeu est actuellement fixÃ©e Ã  CÅ’UR DE FURIE.~
+@1029 = ~Changer la difficultÃ© Ã  CÅ’UR DE FURIE : ~
+@1030 = ~Quel paramÃ¨tre de difficultÃ© voulez-vous changer ?~
 @1031 = ~Je ne veux pas faire de changements pour l'instant.~
-@1032 = ~Vous pouvez apporter d'autres modifications à tout moment, ou utiliser le curseur de difficulté pour apporter des modifications générales à tout composant non paramétré individuellement.~
-@1033 = ~Retirer le contrôle de difficulté de mes capacités spéciales.~
-@1034 = ~Restaurer le contrôle de difficulté dans mes capacités spéciales.~
-@1035 = ~Le contrôle de difficulté a été supprimé. Vous pouvez toujours accéder à ce menu à partir de la console, en saisissant C:CreateCreature("dw#diffi").~
-@1036 = ~Le contrôle de difficulté a été restauré.~
-@1040 = ~Mages (IA générale. le lancement de sorts à l'avance et les capacités de haut niveau sont contrôlés séparément).~
-@1041 = ~Mages (lancement anticipé de sorts avant le combat).~
-@1042 = ~Mages (utilisation des capacités de haut niveau).~
-@1043 = ~Prêtres (IA générale. le lancement de sorts à l'avance et les capacités de haut niveau sont contrôlés séparément).~
-@1044 = ~Prêtres (lancement anticipé de sorts avant le combat).~
-@1045 = ~Prêtres (utilisation des capacités de haut niveau).~
-@1046 = ~Les guerriers, voleurs et l'IA générale et diverse.~
-@1047 = ~Les démons et autres créatures extra-planaires.~
+@1032 = ~Vous pouvez apporter d'autres modifications Ã  tout moment, ou utiliser le curseur de difficultÃ© pour apporter des modifications gÃ©nÃ©rales Ã  tout composant non paramÃ©trÃ© individuellement.~
+@1033 = ~Retirer le contrÃ´le de difficultÃ© de mes capacitÃ©s spÃ©ciales.~
+@1034 = ~Restaurer le contrÃ´le de difficultÃ© dans mes capacitÃ©s spÃ©ciales.~
+@1035 = ~Le contrÃ´le de difficultÃ© a Ã©tÃ© supprimÃ©. Vous pouvez toujours accÃ©der Ã  ce menu Ã  partir de la console, en saisissant C:CreateCreature("dw#diffi").~
+@1036 = ~Le contrÃ´le de difficultÃ© a Ã©tÃ© restaurÃ©.~
+@1040 = ~Mages (IA gÃ©nÃ©rale. le lancement de sorts Ã  l'avance et les capacitÃ©s de haut niveau sont contrÃ´lÃ©s sÃ©parÃ©ment).~
+@1041 = ~Mages (lancement anticipÃ© de sorts avant le combat).~
+@1042 = ~Mages (utilisation des capacitÃ©s de haut niveau).~
+@1043 = ~PrÃªtres (IA gÃ©nÃ©rale. le lancement de sorts Ã  l'avance et les capacitÃ©s de haut niveau sont contrÃ´lÃ©s sÃ©parÃ©ment).~
+@1044 = ~PrÃªtres (lancement anticipÃ© de sorts avant le combat).~
+@1045 = ~PrÃªtres (utilisation des capacitÃ©s de haut niveau).~
+@1046 = ~Les guerriers, voleurs et l'IA gÃ©nÃ©rale et diverse.~
+@1047 = ~Les dÃ©mons et autres crÃ©atures extra-planaires.~
 @1048 = ~Les Dragons.~
 @1049 = ~La tour de Durlag.~
-@1050 = ~La difficulté de ce composant est maintenant fixé à DÉFAUT.~
-@1051 = ~La difficulté de ce composant est maintenant fixé à MODE HISTOIRE.~
-@1052 = ~La difficulté de ce composant est maintenant fixé à FACILE.~
-@1053 = ~La difficulté de ce composant est maintenant fixé à NORMAL.~
-@1054 = ~La difficulté de ce composant est maintenant fixé à RÈGLE DE BASE.~
-@1055 = ~La difficulté de ce composant est maintenant fixé à DIFFICILE.~
-@1056 = ~La difficulté de ce composant est maintenant fixé à TRÈS DIFFICILE.~
-@1057 = ~La difficulté de ce composant est maintenant fixé à SUCCESSION DE BHAAL.~
-@1058 = ~La difficulté de ce composant est maintenant fixé à CŒUR DE FURIE.~
+@1050 = ~La difficultÃ© de ce composant est maintenant fixÃ©e Ã  DÃ‰FAUT.~
+@1051 = ~La difficultÃ© de ce composant est maintenant fixÃ©e Ã  BASIQUE.~
+@1052 = ~La difficultÃ© de ce composant est maintenant fixÃ©e Ã  AMÃ‰LIORÃ‰E.~
+@1053 = ~La difficultÃ© de ce composant est maintenant fixÃ©e Ã  TACTIQUE.~
+@1054 = ~La difficultÃ© de ce composant est maintenant fixÃ©e Ã  DIFFICILE.~
+@1055 = ~La difficultÃ© de ce composant est maintenant fixÃ©e Ã  TRÃˆS DIFFICILE.~
+@1056 = ~La difficultÃ© de ce composant est maintenant fixÃ©e Ã  DÃ‰MENTIELLE.~
+@1057 = ~La difficultÃ© de ce composant est maintenant fixÃ©e Ã  SUCCESSION DE BHAAL.~
+@1058 = ~La difficultÃ© de ce composant est maintenant fixÃ©e Ã  CÅ’UR DE FURIE.~
 @1060 = ~Les flagelleurs mentaux.~
-@1061 = ~Les araignées.~
+@1061 = ~Les araignÃ©es.~
 @1062 = ~Le mod Ascension.~
 @1063 = ~Bodhi.~
-@1064 = ~Les vampires (autre que Bodhi, si vous avez installé "Bodhi améliorée").~
-@1065 = "La cité drow (Ust Natha)."
+@1064 = ~Les vampires (autre que Bodhi, si vous avez installÃ© "Bodhi amÃ©liorÃ©e").~
+@1065 = "La citÃ© drow (Ust Natha)."
 @1066 = "Les spectateurs."
-@1067 = "Le nombre de spectateurs trouvés dans leur ruche en Ombre-Terre."
-@1068 = "Les génies (djinn, efrit et autres)."
+@1067 = "Le nombre de spectateurs trouvÃ©s dans leur ruche en Ombre-Terre."
+@1068 = "Les gÃ©nies (djinn, efrit et autres)."
 @1069 = "Ultime combat de Throne of Bhaal."
-@1070 = "Le composant “Les objets des membres du groupe leur sont enlevés à Spellhold“."
-@1071 = "Les doppelgängers."
+@1070 = "Le composant â€œLes objets des membres du groupe leur sont enlevÃ©s Ã  Spellholdâ€œ."
+@1071 = "Les doppelgÃ¤ngers."
 @1072 = "Rencontres aleatoires de monstres (de BG2)."
-@1073 = "Le château de'Arnise"
+@1073 = "Le chÃ¢teau de'Arnise"
 
-@1100 = "Mode histoire"
-@1101 = "Facile"
-@1102 = "Normal"
-@1103 = "Règle de base"
-@1104 = "Difficile"
-@1105 = "Ce curseur contrôle le niveau de difficulté du jeu. DIFFICILE (à l'extrême droite) : Les ennemis utilisent l'IA la plus sophistiquée, et toutes leurs capacités, et beaucoup d'entre eux ont vu leur nombre et leurs pouvoirs augmentés. Les lanceurs de sorts lancent de nombreux sorts de protection avant le combat. RÈGLE DE BASE (à droite) : Les ennemis utilisent l'IA la plus sophistiquée, et presque toutes leurs capacités, certains ont des augmentations de leur nombre et de leurs pouvoirs. Les lanceurs de sorts lancent quelques sorts de protection à l'avance. NORMAL (au milieu) : Les ennemis utilisent l'IA la plus sophistiquée, et la plupart de leurs capacités, les lanceurs de sorts lancent un petit nombre de sorts de protection à l'avance. \n FACILE (à gauche) : Les ennemis utilisent une IA sophistiquée, mais s'abstiennent d'utiliser leurs capacités les plus puissantes et d'appeler à l'aide. Les lanceurs de sorts ne lancent que les sorts de longue durée à l'avance. MODE HISTOIRE (à l'extrême gauche) : Les ennemis utilisent une IA rudimentaire (à peu près au niveau du jeu non modifié) et s'abstiennent d'utiliser de nombreuses capacités (y compris les pouvoirs de classe). NOTE : vous pouvez régler les paramètres de difficulté pour chaque composant en utilisant le contrôle de difficulté de vos capacités spéciales."
+@1100 = "Basique"
+@1101 = "AmÃ©liorÃ©e"
+@1102 = "Tactique"
+@1103 = "Difficile"
+@1104 = "TrÃ¨s difficile"
+@1105 = "Ce curseur contrÃ´le le niveau de difficultÃ© du jeu. TRÃˆS DIFFICILE (Ã  l'extrÃªme droite) : Les ennemis utilisent l'IA la plus sophistiquÃ©e, et toutes leurs capacitÃ©s, et beaucoup d'entre eux ont vu leur nombre et leurs pouvoirs augmentÃ©s. Les lanceurs de sorts lancent de nombreux sorts de protection avant le combat. DIFFICILE (Ã  droite) : Les ennemis utilisent l'IA la plus sophistiquÃ©e, et presque toutes leurs capacitÃ©s, certains ont des augmentations de leur nombre et de leurs pouvoirs. Les lanceurs de sorts lancent quelques sorts de protection Ã  l'avance. TACTIQUE (au milieu) : Les ennemis utilisent l'IA la plus sophistiquÃ©e, et la plupart de leurs capacitÃ©s, les lanceurs de sorts lancent un petit nombre de sorts de protection Ã  l'avance. \n AMÃ‰LIORÃ‰E (Ã  gauche) : Les ennemis utilisent une IA sophistiquÃ©e, mais s'abstiennent d'utiliser leurs capacitÃ©s les plus puissantes et d'appeler Ã  l'aide. Les lanceurs de sorts ne lancent que les sorts de longue durÃ©e Ã  l'avance. BASIQUE (Ã  l'extrÃªme gauche) : Les ennemis utilisent une IA rudimentaire (Ã  peu prÃ¨s au niveau du jeu non modifiÃ©) et s'abstiennent d'utiliser de nombreuses capacitÃ©s (y compris les pouvoirs de classe). NOTE : vous pouvez rÃ©gler les paramÃ¨tres de difficultÃ© pour chaque composant en utilisant le contrÃ´le de difficultÃ© de vos capacitÃ©s spÃ©ciales."
 
-@1110 = "Ce curseur contrôle le niveau de difficulté du jeu. \n DIFFICILE : Les ennemis utilisent l'IA la plus sophistiquée, et toutes leurs capacités, et beaucoup d'entre eux ont vu leur nombre et leurs pouvoirs augmentés. Les lanceurs de sorts lancent de nombreux sorts de protection avant le combat. \n RÈGLE DE BASE : Les ennemis utilisent l'IA la plus sophistiquée, et presque toutes leurs capacités, certains ont des augmentations de leur nombre et de leurs pouvoirs. Les lanceurs de sorts lancent quelques sorts de protection à l'avance. \n NORMAL : Les ennemis utilisent l'IA la plus sophistiquée, et la plupart de leurs capacités, les lanceurs de sorts lancent un petit nombre de sorts de protection à l'avance. \n FACILE : Les ennemis utilisent une IA sophistiquée, mais s'abstiennent d'utiliser leurs capacités les plus puissantes et d'appeler à l'aide. Les lanceurs de sorts ne lancent que les sorts de longue durée à l'avance. \n MODE HISTOIRE : Les ennemis utilisent une IA rudimentaire (à peu près au niveau du jeu non modifié) et s'abstiennent d'utiliser de nombreuses capacités (y compris les pouvoirs de classe). \n NOTE : vous pouvez régler les paramètres de difficulté pour chaque composant en utilisant le contrôle de difficulté de vos capacités spéciales."
+@1110 = "Ce curseur contrÃ´le le niveau de difficultÃ© du jeu. \n TRÃˆS DIFFICILE : Les ennemis utilisent l'IA la plus sophistiquÃ©e, et toutes leurs capacitÃ©s, et beaucoup d'entre eux ont vu leur nombre et leurs pouvoirs augmentÃ©s. Les lanceurs de sorts lancent de nombreux sorts de protection avant le combat. \n DIFFICILE : Les ennemis utilisent l'IA la plus sophistiquÃ©e, et presque toutes leurs capacitÃ©s, certains ont des augmentations de leur nombre et de leurs pouvoirs. Les lanceurs de sorts lancent quelques sorts de protection Ã  l'avance. \n TACTIQUE : Les ennemis utilisent l'IA la plus sophistiquÃ©e, et la plupart de leurs capacitÃ©s, les lanceurs de sorts lancent un petit nombre de sorts de protection Ã  l'avance. \n AMÃ‰LIORÃ‰E : Les ennemis utilisent une IA sophistiquÃ©e, mais s'abstiennent d'utiliser leurs capacitÃ©s les plus puissantes et d'appeler Ã  l'aide. Les lanceurs de sorts ne lancent que les sorts de longue durÃ©e Ã  l'avance. \n BASIQUE : Les ennemis utilisent une IA rudimentaire (Ã  peu prÃ¨s au niveau du jeu non modifiÃ©) et s'abstiennent d'utiliser de nombreuses capacitÃ©s (y compris les pouvoirs de classe). \n NOTE : vous pouvez rÃ©gler les paramÃ¨tres de difficultÃ© pour chaque composant en utilisant le contrÃ´le de difficultÃ© de vos capacitÃ©s spÃ©ciales."
 
-@1111 = "Les ennemis continuent à cibler intelligemment, utilisent maintenant la plupart de leurs pouvoirs et font souvent appel à l'aide d'alliés proches. Les lanceurs de sorts commencent à lancer quelques sorts en avance avant le combat, surtout s'ils arrivent dans le champ de vision du groupe. Certaines créatures surnaturelles obtiennent la possibilité d'utiliser leurs pouvoirs instantanément et sans interruption possible."
-@1112 = "Les ennemis choisissent leurs cibles et utilisent leurs sorts de manière peu intelligente. Ils s'abstiennent d'utiliser certaines de leurs capacités spéciales et certains de leurs sorts les plus dangereux. Tardivement dans le jeu, certains des lanceurs de sorts les plus puissants commencent à utiliser des capacités de haut niveau. (C'est à peu près le niveau de difficulté avec les règles de base du jeu non modifié)."
-@1113 = "Les ennemis utilisent désormais tous leurs pouvoirs aussi efficacement qu'ils le peuvent. Un petit nombre d'entre eux reçoivent un bonus aux points de vie. Le nombre d'ennemis est parfois augmenté. Les lanceurs de sorts lancent des sorts à l'avance plus fréquemment."
-@1114 = "Plusieurs ennemis reçoivent de nouveaux bonus aux capacités ainsi qu'à leur nombre. Les lanceurs de sorts lancent fréquemment des sorts avant le combat. L'utilisation de capacités de haut niveau se produit désormais (pour les lanceurs de sorts les plus puissants) tout au long du jeu."
-@1115 = "Les ennemis intelligents attaquent et utilisent leurs pouvoirs assez judicieusement, bien que la plupart n'utilisent pas de capacité de classe, et n'utiliseront pas certaines de leurs capacités spéciales les plus dangereuses."
+@1111 = "Les ennemis continuent Ã  cibler intelligemment, utilisent maintenant la plupart de leurs pouvoirs et font souvent appel Ã  l'aide d'alliÃ©s proches. Les lanceurs de sorts commencent Ã  lancer quelques sorts en avance avant le combat, surtout s'ils arrivent dans le champ de vision du groupe. Certaines crÃ©atures surnaturelles obtiennent la possibilitÃ© d'utiliser leurs pouvoirs instantanÃ©ment et sans interruption possible."
+@1112 = "Les ennemis choisissent leurs cibles et utilisent leurs sorts de maniÃ¨re peu intelligente. Ils s'abstiennent d'utiliser certaines de leurs capacitÃ©s spÃ©ciales et certains de leurs sorts les plus dangereux. Tardivement dans le jeu, certains des lanceurs de sorts les plus puissants commencent Ã  utiliser des capacitÃ©s de haut niveau. (C'est Ã  peu prÃ¨s le niveau de difficultÃ© avec les rÃ¨gles de base du jeu non modifiÃ©)."
+@1113 = "Les ennemis utilisent dÃ©sormais tous leurs pouvoirs aussi efficacement qu'ils le peuvent. Un petit nombre d'entre eux reÃ§oivent un bonus aux points de vie. Le nombre d'ennemis est parfois augmentÃ©. Les lanceurs de sorts lancent des sorts Ã  l'avance plus frÃ©quemment."
+@1114 = "Plusieurs ennemis reÃ§oivent de nouveaux bonus aux capacitÃ©s ainsi qu'Ã  leur nombre. Les lanceurs de sorts lancent frÃ©quemment des sorts avant le combat. L'utilisation de capacitÃ©s de haut niveau se produit dÃ©sormais (pour les lanceurs de sorts les plus puissants) tout au long du jeu."
+@1115 = "Les ennemis intelligents attaquent et utilisent leurs pouvoirs assez judicieusement, bien que la plupart n'utilisent pas de capacitÃ© de classe, et n'utiliseront pas certaines de leurs capacitÃ©s spÃ©ciales les plus dangereuses."
 
-@1116 = "NORMAL"
-@1117 = "Normal"
-@1118 = "MODE HISTOIRE"
-@1119 = "Mode histoire"
-@1120 = "RÈGLE DE BASE"
-@1121 = "Règle de base"
-@1124 = "FACILE"
-@1125 = "Facile"
-@1126 = "Aucune modification des dégâts en fonction de la difficulté (fortement recommandé)"
-@1127 = "Empêchez le curseur de difficulté d'apporter des modifications “hardcodées“ aux dégâts causés par les ennemis. (Sword Coast Stratagems présume que cette option est sélectionnée)."
-@1128 = "RÉGLAGE DES PARAMÈTRES DE DIFFICULTÉ"
+@1116 = "TACTIQUE"
+@1117 = "Tactique"
+@1118 = "BASIQUE"
+@1119 = "Basique"
+@1120 = "DIFFICILE"
+@1121 = "Difficile"
+@1124 = "AMÃ‰LIORÃ‰E"
+@1125 = "AmÃ©liorÃ©e"
+@1126 = "Aucune modification des dÃ©gÃ¢ts en fonction de la difficultÃ© (fortement recommandÃ©)"
+@1127 = "EmpÃªchez le curseur de difficultÃ© d'apporter des modifications â€œhardcodÃ©esâ€œ aux dÃ©gÃ¢ts causÃ©s par les ennemis. (Sword Coast Stratagems prÃ©sume que cette option est sÃ©lectionnÃ©e)."
+@1128 = "RÃ‰GLAGE DES PARAMÃˆTRES DE DIFFICULTÃ‰"
 
-@1133 = "Les ennemis utilisent désormais tous leurs pouvoirs aussi efficacement qu'ils le peuvent. Un petit nombre d'entre eux reçoivent un bonus aux points de vie. Le nombre d'ennemis est parfois augmenté. Les lanceurs de sorts lancent des sorts à l'avance plus fréquemment."
-@1134 = "Plusieurs ennemis reçoivent de nouveaux bonus aux capacités ainsi qu'à leur nombre. Les lanceurs de sorts lancent fréquemment des sorts avant le combat."
-@1135 = "Les ennemis ont tous les avantages de la difficulté Difficile ainsi qu'un nombre nettement plus élevé de points de vie, un TAC0 amélioré, de meilleurs jets de sauvegarde et plus d'attaques par tour. Tout lanceur de sort suffisamment puissant utilisera des capacités de haut niveau. Attention : Succession de Bhaal ne peut être sélectionné qu'au lancement d'une partie et une fois sélectionné, ne peut être modifié !"
-@1136 = "Le groupe obtient tous les avantages de la difficulté du mode histoire, et ses membres ne peuvent pas mourir au combat."
+@1133 = "Les ennemis utilisent dÃ©sormais tous leurs pouvoirs aussi efficacement qu'ils le peuvent. Un petit nombre d'entre eux reÃ§oivent un bonus aux points de vie. Le nombre d'ennemis est parfois augmentÃ©. Les lanceurs de sorts lancent des sorts Ã  l'avance plus frÃ©quemment."
+@1134 = "Plusieurs ennemis reÃ§oivent de nouveaux bonus aux capacitÃ©s ainsi qu'Ã  leur nombre. Les lanceurs de sorts lancent frÃ©quemment des sorts avant le combat."
+@1135 = "Les ennemis ont tous les avantages de la difficultÃ© TrÃ¨s difficile ainsi qu'un nombre nettement plus Ã©levÃ© de points de vie, un TAC0 amÃ©liorÃ©, de meilleurs jets de sauvegarde et plus d'attaques par tour. Tout lanceur de sort suffisamment puissant utilisera des capacitÃ©s de haut niveau. Attention : Succession de Bhaal ne peut Ãªtre sÃ©lectionnÃ© qu'au lancement d'une partie et une fois sÃ©lectionnÃ©, ne peut Ãªtre modifiÃ© !"
+@1136 = "Le groupe obtient tous les avantages de la difficultÃ© du mode histoire, et ses membres ne peuvent pas mourir au combat."


### PR DESCRIPTION
These modifications only impact the French translation of the difficulty in SCS.
The present translation does not express the difficulty increase between each level of difficulty.
I have adapted the difficulty label to show the difficulty ramp up.

The modifications are visible in the game option menu and in the difficulty fine tuning panel IG.

Present translation : Défaut, Mode Histoire, Facile, Normal, Règle de base, Difficile, Très Difficile, Succession de Bhaal, Cœur de Furie
Proposed translation : Défaut, Basique, Améliorée, Tactique, Difficile, Très Difficile, Démentielle, Succession de Bhaal, Cœur de Furie

![french diff translation](https://user-images.githubusercontent.com/14138462/193759272-160595ce-6fa1-4af0-843c-cc6aa7338507.png)
