### PR TITLE
Fixes for Improved textscreens in Totsc

### DIFF
--- a/stratagems/gameplay/resource/ulgothst.2da
+++ b/stratagems/gameplay/resource/ulgothst.2da
@@ -1,0 +1,5 @@
+2DA V1.0
+ULGOTHST
+                        0           1
+SWITCH                  DEFAULT     DEFAULT
+DEFAULT                 -1      	224105

--- a/stratagems/gameplay/totsc_textscreens.tpa
+++ b/stratagems/gameplay/totsc_textscreens.tpa
@@ -10,12 +10,11 @@ COPY "music/tday2/tday2a.acm" "override/tday2a.wav"
 ACTION_IF is_eet BEGIN
 	ACTION_GET_STRREF 224105 ulgoth_string
 	STRING_SET 224105 "%ulgoth_string%" [tday2a]
-	LAF install STR_VAR files="dwguiulb.2da" location=resource END
-	LAF install_v2_mos STR_VAR mos_name=dwguiulb mos_loc="%MOD_FOLDER%/%component_loc%/resource" pvrz_loc="%MOD_FOLDER%/%component_loc%/resource" END
+	LAF install STR_VAR files="ulgothst.2da" location=resource END
 
 	COPY_EXISTING "bg1000.bcs" override
 		DECOMPILE_AND_PATCH BEGIN
-			REPLACE_TEXTUALLY ~DisplayString(Myself,224105)~ ~TextScreen("dwguiulb")~
+			REPLACE_TEXTUALLY ~DisplayString(Myself,224105)~ ~TextScreen("ulgothst")~
 		END
 	BUT_ONLY
 END ELSE BEGIN

--- a/stratagems/gameplay/totsc_textscreens.tpa
+++ b/stratagems/gameplay/totsc_textscreens.tpa
@@ -7,28 +7,41 @@ DEFINE_ACTION_FUNCTION totsc_textscreens BEGIN
 LAF check_ini STR_VAR ini=ulgoths_beard_textscreen RET value END
 ACTION_IF value BEGIN
 COPY "music/tday2/tday2a.acm" "override/tday2a.wav"
-ACTION_GET_STRREF 24105 ulgoth_string
-STRING_SET 24105 "%ulgoth_string%" [tday2a]
-LAF install STR_VAR files="dwguiulb.2da" location=resource END
-LAF install_v2_mos STR_VAR mos_name=dwguiulb mos_loc="%MOD_FOLDER%/%component_loc%/resource" pvrz_loc="%MOD_FOLDER%/%component_loc%/resource" END
+ACTION_IF is_eet BEGIN
+	ACTION_GET_STRREF 224105 ulgoth_string
+	STRING_SET 224105 "%ulgoth_string%" [tday2a]
+	LAF install STR_VAR files="dwguiulb.2da" location=resource END
+	LAF install_v2_mos STR_VAR mos_name=dwguiulb mos_loc="%MOD_FOLDER%/%component_loc%/resource" pvrz_loc="%MOD_FOLDER%/%component_loc%/resource" END
 
-COPY_EXISTING "ar1000.bcs" override
-	DECOMPILE_AND_PATCH BEGIN
-		REPLACE_TEXTUALLY ~DisplayString(Myself,24105)~ ~TextScreen("dwguiulb")~
-	END
-BUT_ONLY
+	COPY_EXISTING "bg1000.bcs" override
+		DECOMPILE_AND_PATCH BEGIN
+			REPLACE_TEXTUALLY ~DisplayString(Myself,224105)~ ~TextScreen("dwguiulb")~
+		END
+	BUT_ONLY
+END ELSE BEGIN
+	ACTION_GET_STRREF 24105 ulgoth_string
+	STRING_SET 24105 "%ulgoth_string%" [tday2a]
+	LAF install STR_VAR files="dwguiulb.2da" location=resource END
+	LAF install_v2_mos STR_VAR mos_name=dwguiulb mos_loc="%MOD_FOLDER%/%component_loc%/resource" pvrz_loc="%MOD_FOLDER%/%component_loc%/resource" END
+
+	COPY_EXISTING "ar1000.bcs" override
+		DECOMPILE_AND_PATCH BEGIN
+			REPLACE_TEXTUALLY ~DisplayString(Myself,24105)~ ~TextScreen("dwguiulb")~
+		END
+	BUT_ONLY
+END
 END
 
 // respace the 'go to island' textscreen
 
 LAF check_ini STR_VAR ini=respace_seavoyage_textscreen RET value END
 ACTION_IF value BEGIN
-ACTION_GET_STRREF 23355 islon_string
+ACTION_GET_STRREF (is_eet*200000 + 23355) islon_string
 
 OUTER_PATCH_SAVE islon_string "%islon_string%" BEGIN
 	REPLACE_TEXTUALLY "\(%WNL%\|%LNL%\|%MNL%\)" "%WNL%%WNL%%WNL%%WNL%"
 END
-STRING_SET 23355 "%islon_string%" [TSCNA01]
+STRING_SET_EVALUATE (is_eet*200000 + 23355) "%islon_string%" [TSCNA01]
 
 END
 

--- a/stratagems/gameplay/totsc_textscreens.tpa
+++ b/stratagems/gameplay/totsc_textscreens.tpa
@@ -39,7 +39,7 @@ ACTION_IF value BEGIN
 ACTION_GET_STRREF (is_eet*200000 + 23355) islon_string
 
 OUTER_PATCH_SAVE islon_string "%islon_string%" BEGIN
-	REPLACE_TEXTUALLY "\(%WNL%\|%LNL%\|%MNL%\)" "%WNL%%WNL%%WNL%%WNL%"
+	REPLACE_TEXTUALLY "\(%WNL%\|%LNL%\|%MNL%\)" "\1\1"
 END
 STRING_SET_EVALUATE (is_eet*200000 + 23355) "%islon_string%" [TSCNA01]
 


### PR DESCRIPTION
This pull request does multiple things:
1. Fix the used STRREFs with EET
2. As textscreen of Ulgoth's Beard use ULGOTHST.MOS, which is in BG2EE/EET game files, but nowhere else used afaik