### PR TITLE
Typo in spawning some bandits in Bandit Camp

### DIFF
--- a/stratagems/tactical_bg1/ssl/sealtent.ssl
+++ b/stratagems/tactical_bg1/ssl/sealtent.ssl
@@ -32,11 +32,11 @@ IF
 THEN
 	RESPONSE #100
 		SetGlobal("DMWWRaemonOutside","GLOBAL",1)
-		CreateCreature("dw#c3bt",[3758.979],13)
-		CreateCreature("dw#c3bt",[3720.1019],13)
-		CreateCreature("dw#c3bt",[3673.1032],13)
-		CreateCreature("dw#c3hb",[3781.958],13)
-		CreateCreature("dw#c3hb",[3646.1054],13)
+		CreateCreature("dw#c3bt1",[3758.979],13)
+		CreateCreature("dw#c3bt2",[3720.1019],13)
+		CreateCreature("dw#c3bt3",[3673.1032],13)
+		CreateCreature("dw#c3hb1",[3781.958],13)
+		CreateCreature("dw#c3hb2",[3646.1054],13)
 		CreateCreature("%tutu_var%britik",[3785.1034],13)
 		CreateCreature("%tutu_var%raemon",[3744.1088],13)
 		CreateCreature("%tutu_var%venkt",[3761.1105],13)


### PR DESCRIPTION
Spawn all bandits from tent of Bandit Camp when alarm is triggered.