### PR TITLE
Do not check undefined %difficulty_variable%

### DIFF
--- a/stratagems/tactical_bg1/ssl/laureladd.ssl
+++ b/stratagems/tactical_bg1/ssl/laureladd.ssl
@@ -19,7 +19,6 @@ ACTION
 END
 
 IF TRIGGER
-   TriggerBlock(CorePlus)
 THEN DO
    Action(MakeGibberlings)
 END


### PR DESCRIPTION
Remove checking for difficulty variable in BG1 miscellaneous encounters.
Since this component has no separate difficulty setting.