### PR TITLE
Correct probability for "Conjure Earth Elemental"

### DIFF
--- a/stratagems/elemental_cre/elemental_cre.tpa
+++ b/stratagems/elemental_cre/elemental_cre.tpa
@@ -86,8 +86,8 @@ DEFINE_ACTION_FUNCTION elemental_summoning_bg BEGIN
 	[
 		m_description:=@12
 		m.fx.delete{s_resource==speart1p}
-		m.fx.alter{probability1=69;;probability2=0|match="s_resource==speart2p"}
-		m.fx.alter{probability1=99;;probability2=70|match="s_resource==speart3p"}
+		m.fx.alter{probability1=70;;probability2=0|match="s_resource==speart2p"}
+		m.fx.alter{probability1=100;;probability2=71|match="s_resource==speart3p"}
 	]
 
 	// clone that spell to create the L7 priest Air Elemental spell


### PR DESCRIPTION
The spell "Conjure Earth Elemental" had a 1% chance to not summon any elemental.