### PR TITLE
Define difficulty_variable in bassilus component

### DIFF
--- a/stratagems/tactical_bg1/bassilus.tpa
+++ b/stratagems/tactical_bg1/bassilus.tpa
@@ -2,6 +2,8 @@ INCLUDE ~%MOD_FOLDER%/lib/ai_wrap.tph~
 
 DEFINE_ACTION_FUNCTION bassilus BEGIN
 
+    LAF define_difficulty STR_VAR type=genai RET difficulty_variable END
+
     MAKE_PATCH
        level=>10
        enforce_charclass=>is_bg1


### PR DESCRIPTION
Not sure if it's the correct behavior with genai difficulty.

But for [bassiladd.ssl](https://github.com/Gibberlings3/SwordCoastStratagems/blob/v35.17/stratagems/tactical_bg1/ssl/bassiladd.ssl) `difficulty_variable` needs to be defined.