### PR TITLE
Compatibility with unified worldmap for EET and BP-BGT-Worldmap.

### DIFF
--- a/stratagems/gameplay/wk_early.tpa
+++ b/stratagems/gameplay/wk_early.tpa
@@ -60,7 +60,7 @@ END
 
     // link that entrance point to Watchers' Keep (to the South exit block, to be specific)
 
-    LAF edit_worldmap STR_VAR worldmap=worldm25 editstring="insert_link => ~from=>ar3000 to=>ar4000 dir_from=>S link_travtime_div_four=>9 entrance=>dw#WKin~" END
+    LAF edit_worldmap STR_VAR worldmap = EVAL ~%worldm25%~ editstring="insert_link => ~from=>ar3000 to=>ar4000 dir_from=>S link_travtime_div_four=>9 entrance=>dw#WKin~" END
 
     // Make Tethyr inaccessible once the party have reached the Pocket Plane (not that it matters really)
 
@@ -95,7 +95,7 @@ END
         tooltip_string=>61253
         reachable=>1
      END
-     LAF edit_worldmap STR_VAR worldmap=worldm25 editstring="add_entry=>patch_data" END
+     LAF edit_worldmap STR_VAR worldmap = EVAL ~%worldm25%~ editstring="add_entry=>patch_data" END
 
      // postpone the start movie
      

--- a/stratagems/setup-stratagems.tp2
+++ b/stratagems/setup-stratagems.tp2
@@ -862,6 +862,19 @@ REQUIRE_PREDICATE !GAME_IS ~iwdee~ @50009
 
 REQUIRE_PREDICATE !GAME_IS ~tutu tutu_totsc bgee~ @16000
 
+ACTION_IF (GAME_IS ~eet~ OR MOD_IS_INSTALLED ~SETUP-BP-BGT-WORLDMAP.TP2~ ~1~) BEGIN
+
+	OUTER_SPRINT "worldm25" "worldmap"
+	PRINT ~Unified Worldmap is updated
+	~
+
+END ELSE BEGIN
+
+	OUTER_SPRINT "worldm25" "worldm25"
+	PRINT ~Tob specific Worldmap is updated
+	~
+END
+
 LAF run STR_VAR files=wk_early location=gameplay END
 
 /////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**On BG2EE without EET**, BP-BGT-Worldmap need to be installed before SCS componant 4190 !

Related to this thread : 

- https://www.gibberlings3.net/forums/topic/40131-starting-tob-in-eet-scs-watchers-keep/

And this issue :

- https://github.com/Spellhold-Studios/BP-BGT-Worldmap/issues/3

---

You will probably implement it differently, the Pull Request is here to letting you know.

---